### PR TITLE
updates required for go 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/hack-pad/go-indexeddb
 
-go 1.16
+go 1.18

--- a/idb/base_object_store.go
+++ b/idb/base_object_store.go
@@ -41,7 +41,7 @@ func (b *baseObjectStore) CountKey(key js.Value) (_ *UintRequest, err error) {
 // CountRange returns a UintRequest, and, in a separate thread, returns the total number of records that match the provided KeyRange.
 func (b *baseObjectStore) CountRange(keyRange *KeyRange) (_ *UintRequest, err error) {
 	defer exception.Catch(&err)
-	req := wrapRequest(b.txn, b.jsObjectStore.Call("count", keyRange))
+	req := wrapRequest(b.txn, b.jsObjectStore.Call("count", keyRange.Value))
 	return newUintRequest(req), nil
 }
 
@@ -55,7 +55,7 @@ func (b *baseObjectStore) GetAllKeys() (_ *ArrayRequest, err error) {
 // GetAllKeysRange returns an ArrayRequest that retrieves record keys for all objects in the object store or index matching the specified query. If maxCount is 0, retrieves all objects matching the query.
 func (b *baseObjectStore) GetAllKeysRange(query *KeyRange, maxCount uint) (_ *ArrayRequest, err error) {
 	defer exception.Catch(&err)
-	args := []interface{}{query}
+	args := []interface{}{query.Value}
 	if maxCount > 0 {
 		args = append(args, maxCount)
 	}
@@ -92,7 +92,7 @@ func (b *baseObjectStore) OpenCursorKey(key js.Value, direction CursorDirection)
 // OpenCursorRange is the same as OpenCursor, but opens a cursor over the given range instead.
 func (b *baseObjectStore) OpenCursorRange(keyRange *KeyRange, direction CursorDirection) (_ *CursorWithValueRequest, err error) {
 	defer exception.Catch(&err)
-	req := wrapRequest(b.txn, b.jsObjectStore.Call("openCursor", keyRange, direction.String()))
+	req := wrapRequest(b.txn, b.jsObjectStore.Call("openCursor", keyRange.Value, direction.String()))
 	return newCursorWithValueRequest(req), nil
 }
 
@@ -113,6 +113,6 @@ func (b *baseObjectStore) OpenKeyCursorKey(key js.Value, direction CursorDirecti
 // OpenKeyCursorRange is the same as OpenKeyCursor, but opens a cursor over the given key range instead.
 func (b *baseObjectStore) OpenKeyCursorRange(keyRange *KeyRange, direction CursorDirection) (_ *CursorRequest, err error) {
 	defer exception.Catch(&err)
-	req := wrapRequest(b.txn, b.jsObjectStore.Call("openKeyCursor", keyRange, direction.String()))
+	req := wrapRequest(b.txn, b.jsObjectStore.Call("openKeyCursor", keyRange.Value, direction.String()))
 	return newCursorRequest(req), nil
 }

--- a/idb/db.go
+++ b/idb/db.go
@@ -79,10 +79,10 @@ func (db *Database) TransactionWithOptions(options TransactionOptions, objectSto
 
 	optionsMap := make(map[string]interface{})
 	if options.Durability > 0 {
-		optionsMap["durability"] = options.Durability
+		optionsMap["durability"] = options.Durability.String()
 	}
 
-	args := []interface{}{sliceFromStrings(objectStoreNames), options.Mode}
+	args := []interface{}{sliceFromStrings(objectStoreNames), options.Mode.String()}
 	if len(optionsMap) > 0 {
 		args = append(args, optionsMap)
 	}

--- a/idb/internal/exception/exception_test.go
+++ b/idb/internal/exception/exception_test.go
@@ -68,7 +68,7 @@ func TestCatch(t *testing.T) {
 func testJSErrValue() (value js.Value) {
 	defer func() {
 		recoverVal := recover()
-		value = recoverVal.(js.Wrapper).JSValue()
+		value = recoverVal.(js.Error).Value
 	}()
 	js.Global().Get("Function").New(`throw Exception("some error")`).Invoke()
 	panic("not a JS value. line above should do the panic")

--- a/idb/key_range.go
+++ b/idb/key_range.go
@@ -14,7 +14,7 @@ var (
 
 // KeyRange represents a continuous interval over some data type that is used for keys. Records can be retrieved from ObjectStore and Index objects using keys or a range of keys.
 type KeyRange struct {
-	jsKeyRange js.Value
+	js.Value
 }
 
 func wrapKeyRange(jsKeyRange js.Value) *KeyRange {
@@ -49,34 +49,32 @@ func NewKeyRangeOnly(only js.Value) (_ *KeyRange, err error) {
 // Lower returns the lower bound of the key range.
 func (k *KeyRange) Lower() (_ js.Value, err error) {
 	defer exception.Catch(&err)
-	return k.jsKeyRange.Get("lower"), nil
+	return k.Get("lower"), nil
 }
 
 // Upper returns the upper bound of the key range.
 func (k *KeyRange) Upper() (_ js.Value, err error) {
 	defer exception.Catch(&err)
-	return k.jsKeyRange.Get("upper"), nil
+	return k.Get("upper"), nil
 }
 
 // LowerOpen returns false if the lower-bound value is included in the key range.
 func (k *KeyRange) LowerOpen() (_ bool, err error) {
 	defer exception.Catch(&err)
-	return k.jsKeyRange.Get("lowerOpen").Bool(), nil
+	return k.Get("lowerOpen").Bool(), nil
 }
 
 // UpperOpen returns false if the upper-bound value is included in the key range.
 func (k *KeyRange) UpperOpen() (_ bool, err error) {
 	defer exception.Catch(&err)
-	return k.jsKeyRange.Get("upperOpen").Bool(), nil
+	return k.Get("upperOpen").Bool(), nil
 }
 
 // Includes returns a boolean indicating whether a specified key is inside the key range.
 func (k *KeyRange) Includes(key js.Value) (_ bool, err error) {
 	defer exception.Catch(&err)
-	return k.jsKeyRange.Call("includes", key).Bool(), nil
+	return k.Call("includes", key).Bool(), nil
 }
 
 // JSValue implements js.Wrapper
-func (k *KeyRange) JSValue() js.Value {
-	return k.jsKeyRange
-}
+// removed see : https://github.com/golang/go/issues/44006


### PR DESCRIPTION

This PR contains the changes required to allow go-indexeddb to work with go 1.18

 https://github.com/golang/go/issues/44006  removed js.Wrapper
    KeyRange type is now passed as keyRange.Value in Calls
 
js.ValueOf now appears to be a bit more strict on types
    Various types like CursorDirection are now passed using .String() to Calls
   
 
 
 