### PR TITLE
Fix Go 1.18 compatibility, remove references to js.Wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,19 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - 1.16.x
+          - 1.17.x
+          - 1.18.x
+          - ^1.18  # Latest version of Go
+    name: Test with Go ${{ matrix.go }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
-        go-version: 1.16
+        go-version: ${{ matrix.go }}
+        check_latest: true
     - name: Test
       run: make test

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/hack-pad/go-indexeddb
 
-go 1.16
+go 1.18

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/hack-pad/go-indexeddb
 
-go 1.18
+go 1.16

--- a/idb/base_object_store.go
+++ b/idb/base_object_store.go
@@ -41,7 +41,7 @@ func (b *baseObjectStore) CountKey(key js.Value) (_ *UintRequest, err error) {
 // CountRange returns a UintRequest, and, in a separate thread, returns the total number of records that match the provided KeyRange.
 func (b *baseObjectStore) CountRange(keyRange *KeyRange) (_ *UintRequest, err error) {
 	defer exception.Catch(&err)
-	req := wrapRequest(b.txn, b.jsObjectStore.Call("count", keyRange.Value))
+	req := wrapRequest(b.txn, b.jsObjectStore.Call("count", keyRange.jsKeyRange))
 	return newUintRequest(req), nil
 }
 
@@ -55,7 +55,7 @@ func (b *baseObjectStore) GetAllKeys() (_ *ArrayRequest, err error) {
 // GetAllKeysRange returns an ArrayRequest that retrieves record keys for all objects in the object store or index matching the specified query. If maxCount is 0, retrieves all objects matching the query.
 func (b *baseObjectStore) GetAllKeysRange(query *KeyRange, maxCount uint) (_ *ArrayRequest, err error) {
 	defer exception.Catch(&err)
-	args := []interface{}{query.Value}
+	args := []interface{}{query.jsKeyRange}
 	if maxCount > 0 {
 		args = append(args, maxCount)
 	}
@@ -78,41 +78,41 @@ func (b *baseObjectStore) GetKey(value js.Value) (_ *Request, err error) {
 // OpenCursor returns a CursorWithValueRequest, and, in a separate thread, returns a new CursorWithValue. Used for iterating through an object store or index by primary key with a cursor.
 func (b *baseObjectStore) OpenCursor(direction CursorDirection) (_ *CursorWithValueRequest, err error) {
 	defer exception.Catch(&err)
-	req := wrapRequest(b.txn, b.jsObjectStore.Call("openCursor", js.Null(), direction.String()))
+	req := wrapRequest(b.txn, b.jsObjectStore.Call("openCursor", js.Null(), direction.jsValue()))
 	return newCursorWithValueRequest(req), nil
 }
 
 // OpenCursorKey is the same as OpenCursor, but opens a cursor over the given key instead.
 func (b *baseObjectStore) OpenCursorKey(key js.Value, direction CursorDirection) (_ *CursorWithValueRequest, err error) {
 	defer exception.Catch(&err)
-	req := wrapRequest(b.txn, b.jsObjectStore.Call("openCursor", key, direction.String()))
+	req := wrapRequest(b.txn, b.jsObjectStore.Call("openCursor", key, direction.jsValue()))
 	return newCursorWithValueRequest(req), nil
 }
 
 // OpenCursorRange is the same as OpenCursor, but opens a cursor over the given range instead.
 func (b *baseObjectStore) OpenCursorRange(keyRange *KeyRange, direction CursorDirection) (_ *CursorWithValueRequest, err error) {
 	defer exception.Catch(&err)
-	req := wrapRequest(b.txn, b.jsObjectStore.Call("openCursor", keyRange.Value, direction.String()))
+	req := wrapRequest(b.txn, b.jsObjectStore.Call("openCursor", keyRange.jsKeyRange, direction.jsValue()))
 	return newCursorWithValueRequest(req), nil
 }
 
 // OpenKeyCursor returns a CursorRequest, and, in a separate thread, returns a new Cursor. Used for iterating through all keys in an object store or index.
 func (b *baseObjectStore) OpenKeyCursor(direction CursorDirection) (_ *CursorRequest, err error) {
 	defer exception.Catch(&err)
-	req := wrapRequest(b.txn, b.jsObjectStore.Call("openKeyCursor", js.Null(), direction.String()))
+	req := wrapRequest(b.txn, b.jsObjectStore.Call("openKeyCursor", js.Null(), direction.jsValue()))
 	return newCursorRequest(req), nil
 }
 
 // OpenKeyCursorKey is the same as OpenKeyCursor, but opens a cursor over the given key instead.
 func (b *baseObjectStore) OpenKeyCursorKey(key js.Value, direction CursorDirection) (_ *CursorRequest, err error) {
 	defer exception.Catch(&err)
-	req := wrapRequest(b.txn, b.jsObjectStore.Call("openKeyCursor", key, direction.String()))
+	req := wrapRequest(b.txn, b.jsObjectStore.Call("openKeyCursor", key, direction.jsValue()))
 	return newCursorRequest(req), nil
 }
 
 // OpenKeyCursorRange is the same as OpenKeyCursor, but opens a cursor over the given key range instead.
 func (b *baseObjectStore) OpenKeyCursorRange(keyRange *KeyRange, direction CursorDirection) (_ *CursorRequest, err error) {
 	defer exception.Catch(&err)
-	req := wrapRequest(b.txn, b.jsObjectStore.Call("openKeyCursor", keyRange.Value, direction.String()))
+	req := wrapRequest(b.txn, b.jsObjectStore.Call("openKeyCursor", keyRange.jsKeyRange, direction.jsValue()))
 	return newCursorRequest(req), nil
 }

--- a/idb/base_object_store.go
+++ b/idb/base_object_store.go
@@ -41,7 +41,7 @@ func (b *baseObjectStore) CountKey(key js.Value) (_ *UintRequest, err error) {
 // CountRange returns a UintRequest, and, in a separate thread, returns the total number of records that match the provided KeyRange.
 func (b *baseObjectStore) CountRange(keyRange *KeyRange) (_ *UintRequest, err error) {
 	defer exception.Catch(&err)
-	req := wrapRequest(b.txn, b.jsObjectStore.Call("count", keyRange))
+	req := wrapRequest(b.txn, b.jsObjectStore.Call("count", keyRange.Value))
 	return newUintRequest(req), nil
 }
 
@@ -55,7 +55,7 @@ func (b *baseObjectStore) GetAllKeys() (_ *ArrayRequest, err error) {
 // GetAllKeysRange returns an ArrayRequest that retrieves record keys for all objects in the object store or index matching the specified query. If maxCount is 0, retrieves all objects matching the query.
 func (b *baseObjectStore) GetAllKeysRange(query *KeyRange, maxCount uint) (_ *ArrayRequest, err error) {
 	defer exception.Catch(&err)
-	args := []interface{}{query}
+	args := []interface{}{query.Value}
 	if maxCount > 0 {
 		args = append(args, maxCount)
 	}
@@ -92,7 +92,7 @@ func (b *baseObjectStore) OpenCursorKey(key js.Value, direction CursorDirection)
 // OpenCursorRange is the same as OpenCursor, but opens a cursor over the given range instead.
 func (b *baseObjectStore) OpenCursorRange(keyRange *KeyRange, direction CursorDirection) (_ *CursorWithValueRequest, err error) {
 	defer exception.Catch(&err)
-	req := wrapRequest(b.txn, b.jsObjectStore.Call("openCursor", keyRange, direction.String()))
+	req := wrapRequest(b.txn, b.jsObjectStore.Call("openCursor", keyRange.Value, direction.String()))
 	return newCursorWithValueRequest(req), nil
 }
 
@@ -113,6 +113,6 @@ func (b *baseObjectStore) OpenKeyCursorKey(key js.Value, direction CursorDirecti
 // OpenKeyCursorRange is the same as OpenKeyCursor, but opens a cursor over the given key range instead.
 func (b *baseObjectStore) OpenKeyCursorRange(keyRange *KeyRange, direction CursorDirection) (_ *CursorRequest, err error) {
 	defer exception.Catch(&err)
-	req := wrapRequest(b.txn, b.jsObjectStore.Call("openKeyCursor", keyRange, direction.String()))
+	req := wrapRequest(b.txn, b.jsObjectStore.Call("openKeyCursor", keyRange.Value, direction.String()))
 	return newCursorRequest(req), nil
 }

--- a/idb/cursor.go
+++ b/idb/cursor.go
@@ -6,10 +6,12 @@ import (
 	"syscall/js"
 
 	"github.com/hack-pad/go-indexeddb/idb/internal/exception"
+	"github.com/hack-pad/go-indexeddb/idb/internal/jscache"
 )
 
 var (
-	jsObjectStore = js.Global().Get("IDBObjectStore")
+	jsObjectStore        = js.Global().Get("IDBObjectStore")
+	cursorDirectionCache jscache.Strings
 )
 
 // CursorDirection is the direction of traversal of the cursor
@@ -50,6 +52,10 @@ func (d CursorDirection) String() string {
 	default:
 		return "next"
 	}
+}
+
+func (d CursorDirection) jsValue() js.Value {
+	return cursorDirectionCache.Value(d.String())
 }
 
 // Cursor represents a cursor for traversing or iterating over multiple records in a Database

--- a/idb/db.go
+++ b/idb/db.go
@@ -78,11 +78,11 @@ func (db *Database) TransactionWithOptions(options TransactionOptions, objectSto
 	objectStoreNames = append([]string{objectStoreName}, objectStoreNames...) // require at least one name
 
 	optionsMap := make(map[string]interface{})
-	if options.Durability > 0 {
-		optionsMap["durability"] = options.Durability.String()
+	if options.Durability != DurabilityDefault {
+		optionsMap["durability"] = options.Durability.jsValue()
 	}
 
-	args := []interface{}{sliceFromStrings(objectStoreNames), options.Mode.String()}
+	args := []interface{}{sliceFromStrings(objectStoreNames), options.Mode.jsValue()}
 	if len(optionsMap) > 0 {
 		args = append(args, optionsMap)
 	}

--- a/idb/db.go
+++ b/idb/db.go
@@ -79,10 +79,10 @@ func (db *Database) TransactionWithOptions(options TransactionOptions, objectSto
 
 	optionsMap := make(map[string]interface{})
 	if options.Durability > 0 {
-		optionsMap["durability"] = options.Durability
+		optionsMap["durability"] = options.Durability.String()
 	}
 
-	args := []interface{}{sliceFromStrings(objectStoreNames), options.Mode}
+	args := []interface{}{sliceFromStrings(objectStoreNames), options.Mode.String()}
 	if len(optionsMap) > 0 {
 		args = append(args, optionsMap)
 	}

--- a/idb/internal/exception/exception_test.go
+++ b/idb/internal/exception/exception_test.go
@@ -68,7 +68,7 @@ func TestCatch(t *testing.T) {
 func testJSErrValue() (value js.Value) {
 	defer func() {
 		recoverVal := recover()
-		value = recoverVal.(js.Wrapper).JSValue()
+		value = recoverVal.(js.Error).Value
 	}()
 	js.Global().Get("Function").New(`throw Exception("some error")`).Invoke()
 	panic("not a JS value. line above should do the panic")

--- a/idb/key_range.go
+++ b/idb/key_range.go
@@ -14,7 +14,7 @@ var (
 
 // KeyRange represents a continuous interval over some data type that is used for keys. Records can be retrieved from ObjectStore and Index objects using keys or a range of keys.
 type KeyRange struct {
-	jsKeyRange js.Value
+	js.Value
 }
 
 func wrapKeyRange(jsKeyRange js.Value) *KeyRange {
@@ -49,34 +49,32 @@ func NewKeyRangeOnly(only js.Value) (_ *KeyRange, err error) {
 // Lower returns the lower bound of the key range.
 func (k *KeyRange) Lower() (_ js.Value, err error) {
 	defer exception.Catch(&err)
-	return k.jsKeyRange.Get("lower"), nil
+	return k.Get("lower"), nil
 }
 
 // Upper returns the upper bound of the key range.
 func (k *KeyRange) Upper() (_ js.Value, err error) {
 	defer exception.Catch(&err)
-	return k.jsKeyRange.Get("upper"), nil
+	return k.Get("upper"), nil
 }
 
 // LowerOpen returns false if the lower-bound value is included in the key range.
 func (k *KeyRange) LowerOpen() (_ bool, err error) {
 	defer exception.Catch(&err)
-	return k.jsKeyRange.Get("lowerOpen").Bool(), nil
+	return k.Get("lowerOpen").Bool(), nil
 }
 
 // UpperOpen returns false if the upper-bound value is included in the key range.
 func (k *KeyRange) UpperOpen() (_ bool, err error) {
 	defer exception.Catch(&err)
-	return k.jsKeyRange.Get("upperOpen").Bool(), nil
+	return k.Get("upperOpen").Bool(), nil
 }
 
 // Includes returns a boolean indicating whether a specified key is inside the key range.
 func (k *KeyRange) Includes(key js.Value) (_ bool, err error) {
 	defer exception.Catch(&err)
-	return k.jsKeyRange.Call("includes", key).Bool(), nil
+	return k.Call("includes", key).Bool(), nil
 }
 
 // JSValue implements js.Wrapper
-func (k *KeyRange) JSValue() js.Value {
-	return k.jsKeyRange
-}
+// removed see : https://github.com/golang/go/issues/44006

--- a/idb/key_range.go
+++ b/idb/key_range.go
@@ -14,7 +14,7 @@ var (
 
 // KeyRange represents a continuous interval over some data type that is used for keys. Records can be retrieved from ObjectStore and Index objects using keys or a range of keys.
 type KeyRange struct {
-	js.Value
+	jsKeyRange js.Value
 }
 
 func wrapKeyRange(jsKeyRange js.Value) *KeyRange {
@@ -49,32 +49,29 @@ func NewKeyRangeOnly(only js.Value) (_ *KeyRange, err error) {
 // Lower returns the lower bound of the key range.
 func (k *KeyRange) Lower() (_ js.Value, err error) {
 	defer exception.Catch(&err)
-	return k.Get("lower"), nil
+	return k.jsKeyRange.Get("lower"), nil
 }
 
 // Upper returns the upper bound of the key range.
 func (k *KeyRange) Upper() (_ js.Value, err error) {
 	defer exception.Catch(&err)
-	return k.Get("upper"), nil
+	return k.jsKeyRange.Get("upper"), nil
 }
 
 // LowerOpen returns false if the lower-bound value is included in the key range.
 func (k *KeyRange) LowerOpen() (_ bool, err error) {
 	defer exception.Catch(&err)
-	return k.Get("lowerOpen").Bool(), nil
+	return k.jsKeyRange.Get("lowerOpen").Bool(), nil
 }
 
 // UpperOpen returns false if the upper-bound value is included in the key range.
 func (k *KeyRange) UpperOpen() (_ bool, err error) {
 	defer exception.Catch(&err)
-	return k.Get("upperOpen").Bool(), nil
+	return k.jsKeyRange.Get("upperOpen").Bool(), nil
 }
 
 // Includes returns a boolean indicating whether a specified key is inside the key range.
 func (k *KeyRange) Includes(key js.Value) (_ bool, err error) {
 	defer exception.Catch(&err)
-	return k.Call("includes", key).Bool(), nil
+	return k.jsKeyRange.Call("includes", key).Bool(), nil
 }
-
-// JSValue implements js.Wrapper
-// removed see : https://github.com/golang/go/issues/44006

--- a/idb/transaction.go
+++ b/idb/transaction.go
@@ -51,8 +51,7 @@ func (m TransactionMode) String() string {
 	}
 }
 
-// JSValue implements js.Wrapper
-func (m TransactionMode) JSValue() js.Value {
+func (m TransactionMode) jsValue() js.Value {
 	return modeCache.Value(m.String())
 }
 
@@ -90,8 +89,7 @@ func (d TransactionDurability) String() string {
 	}
 }
 
-// JSValue implements js.Wrapper
-func (d TransactionDurability) JSValue() js.Value {
+func (d TransactionDurability) jsValue() js.Value {
 	return durabilityCache.Value(d.String())
 }
 


### PR DESCRIPTION
Go 1.18 removed `js.Wrapper`, so automatic conversions of `JSValue()` methods no longer works.

Includes @mlctrez's great start from this [PR](https://github.com/hack-pad/go-indexeddb/pull/2), adds a Go 1.18 test run, and removes the old `.JSValue()` pattern entirely.

This is a breaking change, so slating this for `v0.2`.