### PR TITLE
Update GitHub Actions to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
-        go-version: 1.16
+        go-version: 1.16.x
     - name: Lint
       run: make lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,6 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
-        check_latest: true
+        check-latest: true
     - name: Test
       run: make test


### PR DESCRIPTION
Update GitHub Actions to v3. Also ensures works on latest version of Go
