### PR TITLE
Attempt to parse exceptions as DOMException type with errors.Is() support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         go:
           - 1.18.x
-          - ^1.18  # Latest version of Go
+          - 1.19.x
     name: Test with Go ${{ matrix.go }}
     steps:
     - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BROWSERTEST_VERSION = v0.6
+BROWSERTEST_VERSION = v0.7
 LINT_VERSION = 1.50.1
 GO_BIN = $(shell printf '%s/bin' "$$(go env GOPATH)")
 

--- a/idb/base_object_store.go
+++ b/idb/base_object_store.go
@@ -27,7 +27,7 @@ func wrapBaseObjectStore(txn *Transaction, jsObjectStore safejs.Value) *baseObje
 func (b *baseObjectStore) Count() (*UintRequest, error) {
 	reqValue, err := b.jsObjectStore.Call("count")
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	req := wrapRequest(b.txn, reqValue)
 	return newUintRequest(req), nil
@@ -37,7 +37,7 @@ func (b *baseObjectStore) Count() (*UintRequest, error) {
 func (b *baseObjectStore) CountKey(key safejs.Value) (*UintRequest, error) {
 	reqValue, err := b.jsObjectStore.Call("count", key)
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	req := wrapRequest(b.txn, reqValue)
 	return newUintRequest(req), nil
@@ -47,7 +47,7 @@ func (b *baseObjectStore) CountKey(key safejs.Value) (*UintRequest, error) {
 func (b *baseObjectStore) CountRange(keyRange *KeyRange) (*UintRequest, error) {
 	reqValue, err := b.jsObjectStore.Call("count", keyRange.jsKeyRange)
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	req := wrapRequest(b.txn, reqValue)
 	return newUintRequest(req), nil
@@ -57,7 +57,7 @@ func (b *baseObjectStore) CountRange(keyRange *KeyRange) (*UintRequest, error) {
 func (b *baseObjectStore) GetAllKeys() (*ArrayRequest, error) {
 	reqValue, err := b.jsObjectStore.Call("getAllKeys")
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	req := wrapRequest(b.txn, reqValue)
 	return newArrayRequest(req), nil
@@ -71,7 +71,7 @@ func (b *baseObjectStore) GetAllKeysRange(query *KeyRange, maxCount uint) (*Arra
 	}
 	reqValue, err := b.jsObjectStore.Call("getAllKeys", args...)
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	req := wrapRequest(b.txn, reqValue)
 	return newArrayRequest(req), nil
@@ -81,7 +81,7 @@ func (b *baseObjectStore) GetAllKeysRange(query *KeyRange, maxCount uint) (*Arra
 func (b *baseObjectStore) Get(key safejs.Value) (*Request, error) {
 	reqValue, err := b.jsObjectStore.Call("get", key)
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	return wrapRequest(b.txn, reqValue), nil
 }
@@ -90,7 +90,7 @@ func (b *baseObjectStore) Get(key safejs.Value) (*Request, error) {
 func (b *baseObjectStore) GetKey(value safejs.Value) (*Request, error) {
 	reqValue, err := b.jsObjectStore.Call("getKey", value)
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	return wrapRequest(b.txn, reqValue), nil
 }
@@ -99,7 +99,7 @@ func (b *baseObjectStore) GetKey(value safejs.Value) (*Request, error) {
 func (b *baseObjectStore) OpenCursor(direction CursorDirection) (*CursorWithValueRequest, error) {
 	reqValue, err := b.jsObjectStore.Call("openCursor", safejs.Null(), direction.jsValue())
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	req := wrapRequest(b.txn, reqValue)
 	return newCursorWithValueRequest(req), nil
@@ -109,7 +109,7 @@ func (b *baseObjectStore) OpenCursor(direction CursorDirection) (*CursorWithValu
 func (b *baseObjectStore) OpenCursorKey(key safejs.Value, direction CursorDirection) (*CursorWithValueRequest, error) {
 	reqValue, err := b.jsObjectStore.Call("openCursor", key, direction.jsValue())
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	req := wrapRequest(b.txn, reqValue)
 	return newCursorWithValueRequest(req), nil
@@ -119,7 +119,7 @@ func (b *baseObjectStore) OpenCursorKey(key safejs.Value, direction CursorDirect
 func (b *baseObjectStore) OpenCursorRange(keyRange *KeyRange, direction CursorDirection) (*CursorWithValueRequest, error) {
 	reqValue, err := b.jsObjectStore.Call("openCursor", keyRange.jsKeyRange, direction.jsValue())
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	req := wrapRequest(b.txn, reqValue)
 	return newCursorWithValueRequest(req), nil
@@ -129,7 +129,7 @@ func (b *baseObjectStore) OpenCursorRange(keyRange *KeyRange, direction CursorDi
 func (b *baseObjectStore) OpenKeyCursor(direction CursorDirection) (*CursorRequest, error) {
 	reqValue, err := b.jsObjectStore.Call("openKeyCursor", safejs.Null(), direction.jsValue())
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	req := wrapRequest(b.txn, reqValue)
 	return newCursorRequest(req), nil
@@ -139,7 +139,7 @@ func (b *baseObjectStore) OpenKeyCursor(direction CursorDirection) (*CursorReque
 func (b *baseObjectStore) OpenKeyCursorKey(key safejs.Value, direction CursorDirection) (*CursorRequest, error) {
 	reqValue, err := b.jsObjectStore.Call("openKeyCursor", key, direction.jsValue())
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	req := wrapRequest(b.txn, reqValue)
 	return newCursorRequest(req), nil
@@ -149,7 +149,7 @@ func (b *baseObjectStore) OpenKeyCursorKey(key safejs.Value, direction CursorDir
 func (b *baseObjectStore) OpenKeyCursorRange(keyRange *KeyRange, direction CursorDirection) (*CursorRequest, error) {
 	reqValue, err := b.jsObjectStore.Call("openKeyCursor", keyRange.jsKeyRange, direction.jsValue())
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	req := wrapRequest(b.txn, reqValue)
 	return newCursorRequest(req), nil

--- a/idb/cursor.go
+++ b/idb/cursor.go
@@ -133,35 +133,35 @@ func (c *Cursor) Request() (*Request, error) {
 func (c *Cursor) Advance(count uint) error {
 	c.iterated = true
 	_, err := c.jsCursor.Call("advance", count)
-	return err
+	return tryAsDOMException(err)
 }
 
 // Continue advances the cursor to the next position along its direction.
 func (c *Cursor) Continue() error {
 	c.iterated = true
 	_, err := c.jsCursor.Call("continue")
-	return err
+	return tryAsDOMException(err)
 }
 
 // ContinueKey advances the cursor to the next position along its direction.
 func (c *Cursor) ContinueKey(key js.Value) error {
 	c.iterated = true
 	_, err := c.jsCursor.Call("continue", key)
-	return err
+	return tryAsDOMException(err)
 }
 
 // ContinuePrimaryKey sets the cursor to the given index key and primary key given as arguments. Returns an error if the source is not an index.
 func (c *Cursor) ContinuePrimaryKey(key, primaryKey js.Value) error {
 	c.iterated = true
 	_, err := c.jsCursor.Call("continuePrimaryKey", key, primaryKey)
-	return err
+	return tryAsDOMException(err)
 }
 
 // Delete returns an AckRequest, and, in a separate thread, deletes the record at the cursor's position, without changing the cursor's position. This can be used to delete specific records.
 func (c *Cursor) Delete() (*AckRequest, error) {
 	reqValue, err := c.jsCursor.Call("delete")
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	req := wrapRequest(c.txn, reqValue)
 	return newAckRequest(req), nil
@@ -171,7 +171,7 @@ func (c *Cursor) Delete() (*AckRequest, error) {
 func (c *Cursor) Update(value js.Value) (*Request, error) {
 	reqValue, err := c.jsCursor.Call("update", value)
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	return wrapRequest(c.txn, reqValue), nil
 }

--- a/idb/db.go
+++ b/idb/db.go
@@ -53,7 +53,7 @@ func (db *Database) CreateObjectStore(name string, options ObjectStoreOptions) (
 		"keyPath":       options.KeyPath,
 	})
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	return wrapObjectStore(nil, jsObjectStore), nil
 }
@@ -61,13 +61,13 @@ func (db *Database) CreateObjectStore(name string, options ObjectStoreOptions) (
 // DeleteObjectStore destroys the object store with the given name in the connected database, along with any indexes that reference it.
 func (db *Database) DeleteObjectStore(name string) error {
 	_, err := db.jsDB.Call("deleteObjectStore", name)
-	return err
+	return tryAsDOMException(err)
 }
 
 // Close closes the connection to a database.
 func (db *Database) Close() error {
 	_, err := db.jsDB.Call("close")
-	return err
+	return tryAsDOMException(err)
 }
 
 // Transaction returns a transaction object containing the Transaction.ObjectStore() method, which you can use to access your object store.
@@ -97,7 +97,7 @@ func (db *Database) TransactionWithOptions(options TransactionOptions, objectSto
 
 	jsTxn, err := db.jsDB.Call("transaction", args...)
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	return wrapTransaction(db, jsTxn), nil
 }

--- a/idb/db_factory.go
+++ b/idb/db_factory.go
@@ -64,7 +64,7 @@ func (f *Factory) Open(upgradeCtx context.Context, name string, version uint, up
 	}
 	reqValue, err := f.jsFactory.Call("open", args...)
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	req := wrapRequest(nil, reqValue)
 	return newOpenDBRequest(upgradeCtx, req, upgrader)
@@ -74,7 +74,7 @@ func (f *Factory) Open(upgradeCtx context.Context, name string, version uint, up
 func (f *Factory) DeleteDatabase(name string) (*AckRequest, error) {
 	reqValue, err := f.jsFactory.Call("deleteDatabase", name)
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	req := wrapRequest(nil, reqValue)
 	return newAckRequest(req), nil
@@ -84,7 +84,7 @@ func (f *Factory) DeleteDatabase(name string) (*AckRequest, error) {
 func (f *Factory) CompareKeys(a, b js.Value) (int, error) {
 	compare, err := f.jsFactory.Call("cmp", a, b)
 	if err != nil {
-		return 0, err
+		return 0, tryAsDOMException(err)
 	}
 	return compare.Int()
 }

--- a/idb/dom_exception.go
+++ b/idb/dom_exception.go
@@ -1,0 +1,68 @@
+//go:build js && wasm
+// +build js,wasm
+
+package idb
+
+import (
+	"syscall/js"
+
+	"github.com/hack-pad/safejs"
+)
+
+type DOMException struct {
+	name    string
+	message string
+}
+
+func tryAsDOMException(err error) error {
+	switch err := err.(type) {
+	case js.Error:
+		return domExceptionAsError(safejs.Safe(err.Value))
+	default:
+		return err
+	}
+}
+
+func domExceptionAsError(jsDOMException safejs.Value) error {
+	truthy, err := jsDOMException.Truthy()
+	if err != nil || !truthy {
+		return err
+	}
+	domException, err := parseJSDOMException(jsDOMException)
+	if err != nil {
+		return err
+	}
+	return domException
+}
+
+func parseJSDOMException(jsDOMException safejs.Value) (DOMException, error) {
+	name, err := jsDOMException.Get("name")
+	if err != nil {
+		return DOMException{}, err
+	}
+	nameStr, err := name.String()
+	if err != nil {
+		return DOMException{}, err
+	}
+	message, err := jsDOMException.Get("message")
+	if err != nil {
+		return DOMException{}, err
+	}
+	messageStr, err := message.String()
+	if err != nil {
+		return DOMException{}, err
+	}
+	return DOMException{
+		name:    nameStr,
+		message: messageStr,
+	}, nil
+}
+
+func (e DOMException) Error() string {
+	return e.name + ": " + e.message
+}
+
+func (e DOMException) Is(target error) bool {
+	targetDOMException, ok := target.(DOMException)
+	return ok && targetDOMException.name == e.name
+}

--- a/idb/dom_exception.go
+++ b/idb/dom_exception.go
@@ -30,6 +30,8 @@ func domExceptionAsError(jsDOMException safejs.Value) error {
 	return domException
 }
 
+// DOMException is a JavaScript DOMException with a standard name.
+// Use errors.Is() to compare by name.
 type DOMException struct {
 	name    string
 	message string
@@ -71,6 +73,7 @@ func (e DOMException) Error() string {
 	return e.name + ": " + e.message
 }
 
+// Is returns true target is a DOMException and matches this DOMException's name. Use 'errors.Is()' to call it.
 func (e DOMException) Is(target error) bool {
 	targetDOMException, ok := target.(DOMException)
 	return ok && targetDOMException.name == e.name

--- a/idb/dom_exception.go
+++ b/idb/dom_exception.go
@@ -9,11 +9,6 @@ import (
 	"github.com/hack-pad/safejs"
 )
 
-type DOMException struct {
-	name    string
-	message string
-}
-
 func tryAsDOMException(err error) error {
 	switch err := err.(type) {
 	case js.Error:
@@ -33,6 +28,17 @@ func domExceptionAsError(jsDOMException safejs.Value) error {
 		return err
 	}
 	return domException
+}
+
+type DOMException struct {
+	name    string
+	message string
+}
+
+// NewDOMException returns a new DOMException with the given name.
+// Only useful for errors.Is() comparisons with errors returned from idb.
+func NewDOMException(name string) DOMException {
+	return DOMException{name: name}
 }
 
 func parseJSDOMException(jsDOMException safejs.Value) (DOMException, error) {
@@ -59,6 +65,9 @@ func parseJSDOMException(jsDOMException safejs.Value) (DOMException, error) {
 }
 
 func (e DOMException) Error() string {
+	if e.message == "" {
+		return e.name
+	}
 	return e.name + ": " + e.message
 }
 

--- a/idb/dom_exception_test.go
+++ b/idb/dom_exception_test.go
@@ -1,0 +1,49 @@
+//go:build js && wasm
+// +build js,wasm
+
+package idb
+
+import (
+	"syscall/js"
+	"testing"
+
+	"github.com/hack-pad/go-indexeddb/idb/internal/assert"
+	"github.com/hack-pad/safejs"
+)
+
+var domException safejs.Value
+
+func init() {
+	var err error
+	domException, err = safejs.Global().Get("DOMException")
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestTryAsDOMException(t *testing.T) {
+	t.Parallel()
+	exceptionJS, err := domException.New("message", "name")
+	assert.NoError(t, err)
+	exception := js.Error{Value: safejs.Unsafe(exceptionJS)}
+	assert.Equal(t, DOMException{
+		name:    "name",
+		message: "message",
+	}, tryAsDOMException(exception))
+}
+
+func TestDOMExceptionAsError(t *testing.T) {
+	t.Parallel()
+	exceptionJS, err := domException.New("message", "name")
+	assert.NoError(t, err)
+	exception := domExceptionAsError(exceptionJS)
+	assert.Equal(t, DOMException{
+		name:    "name",
+		message: "message",
+	}, exception)
+
+	assert.Equal(t, "name: message", exception.Error())
+
+	assert.ErrorIs(t, exception, DOMException{name: "name"})
+	assert.NotErrorIs(t, exception, DOMException{name: "other name"})
+}

--- a/idb/internal/assert/assert.go
+++ b/idb/internal/assert/assert.go
@@ -43,6 +43,16 @@ func ErrorIs(tb testing.TB, err, target error) bool {
 	return true
 }
 
+// NotErrorIs asserts err does match target
+func NotErrorIs(tb testing.TB, err, target error) bool {
+	tb.Helper()
+	if errors.Is(err, target) {
+		tb.Error("Expected error not to match", target, ", got:", err)
+		return false
+	}
+	return true
+}
+
 // Zero asserts value is the zero value
 func Zero(tb testing.TB, value interface{}) bool {
 	tb.Helper()

--- a/idb/internal/assert/assert.go
+++ b/idb/internal/assert/assert.go
@@ -6,6 +6,7 @@ package assert
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -27,6 +28,16 @@ func NoError(tb testing.TB, err error) bool {
 	tb.Helper()
 	if err != nil {
 		tb.Errorf("Unexpected error: %+v", err)
+		return false
+	}
+	return true
+}
+
+// ErrorIs asserts err matches target
+func ErrorIs(tb testing.TB, err, target error) bool {
+	tb.Helper()
+	if !errors.Is(err, target) {
+		tb.Error("Expected error to match", target, ", got:", err)
 		return false
 	}
 	return true

--- a/idb/key_range.go
+++ b/idb/key_range.go
@@ -35,7 +35,7 @@ func wrapKeyRange(jsKeyRange safejs.Value) *KeyRange {
 func NewKeyRangeBound(lower, upper js.Value, lowerOpen, upperOpen bool) (*KeyRange, error) {
 	keyRange, err := jsIDBKeyRange.Call("bound", lower, upper, lowerOpen, upperOpen)
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	return wrapKeyRange(keyRange), nil
 }
@@ -44,7 +44,7 @@ func NewKeyRangeBound(lower, upper js.Value, lowerOpen, upperOpen bool) (*KeyRan
 func NewKeyRangeLowerBound(lower js.Value, open bool) (*KeyRange, error) {
 	keyRange, err := jsIDBKeyRange.Call("lowerBound", lower, open)
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	return wrapKeyRange(keyRange), nil
 }
@@ -53,7 +53,7 @@ func NewKeyRangeLowerBound(lower js.Value, open bool) (*KeyRange, error) {
 func NewKeyRangeUpperBound(upper js.Value, open bool) (*KeyRange, error) {
 	keyRange, err := jsIDBKeyRange.Call("upperBound", upper, open)
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	return wrapKeyRange(keyRange), nil
 }
@@ -62,7 +62,7 @@ func NewKeyRangeUpperBound(upper js.Value, open bool) (*KeyRange, error) {
 func NewKeyRangeOnly(only js.Value) (*KeyRange, error) {
 	keyRange, err := jsIDBKeyRange.Call("only", only)
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	return wrapKeyRange(keyRange), nil
 }
@@ -101,7 +101,7 @@ func (k *KeyRange) UpperOpen() (bool, error) {
 func (k *KeyRange) Includes(key js.Value) (bool, error) {
 	includes, err := k.jsKeyRange.Call("includes", key)
 	if err != nil {
-		return false, err
+		return false, tryAsDOMException(err)
 	}
 	return includes.Bool()
 }

--- a/idb/object_store.go
+++ b/idb/object_store.go
@@ -69,7 +69,7 @@ func (o *ObjectStore) AutoIncrement() (bool, error) {
 func (o *ObjectStore) Add(value js.Value) (*AckRequest, error) {
 	reqValue, err := o.base.jsObjectStore.Call("add", value)
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	req := wrapRequest(o.base.txn, reqValue)
 	return newAckRequest(req), nil
@@ -79,7 +79,7 @@ func (o *ObjectStore) Add(value js.Value) (*AckRequest, error) {
 func (o *ObjectStore) AddKey(key, value js.Value) (*AckRequest, error) {
 	reqValue, err := o.base.jsObjectStore.Call("add", value, key)
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	req := wrapRequest(o.base.txn, reqValue)
 	return newAckRequest(req), nil
@@ -89,7 +89,7 @@ func (o *ObjectStore) AddKey(key, value js.Value) (*AckRequest, error) {
 func (o *ObjectStore) Clear() (*AckRequest, error) {
 	reqValue, err := o.base.jsObjectStore.Call("clear")
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	req := wrapRequest(o.base.txn, reqValue)
 	return newAckRequest(req), nil
@@ -117,7 +117,7 @@ func (o *ObjectStore) CreateIndex(name string, keyPath js.Value, options IndexOp
 		"multiEntry": options.MultiEntry,
 	})
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	return wrapIndex(o.base.txn, jsIndex), nil
 }
@@ -126,7 +126,7 @@ func (o *ObjectStore) CreateIndex(name string, keyPath js.Value, options IndexOp
 func (o *ObjectStore) Delete(key js.Value) (*AckRequest, error) {
 	reqValue, err := o.base.jsObjectStore.Call("delete", key)
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	req := wrapRequest(o.base.txn, reqValue)
 	return newAckRequest(req), nil
@@ -135,7 +135,7 @@ func (o *ObjectStore) Delete(key js.Value) (*AckRequest, error) {
 // DeleteIndex destroys the specified index in the connected database, used during a version upgrade.
 func (o *ObjectStore) DeleteIndex(name string) error {
 	_, err := o.base.jsObjectStore.Call("deleteIndex", name)
-	return err
+	return tryAsDOMException(err)
 }
 
 // GetAllKeys returns an ArrayRequest that retrieves record keys for all objects in the object store.
@@ -162,7 +162,7 @@ func (o *ObjectStore) GetKey(value js.Value) (*Request, error) {
 func (o *ObjectStore) Index(name string) (*Index, error) {
 	jsIndex, err := o.base.jsObjectStore.Call("index", name)
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	return wrapIndex(o.base.txn, jsIndex), nil
 }
@@ -171,7 +171,7 @@ func (o *ObjectStore) Index(name string) (*Index, error) {
 func (o *ObjectStore) Put(value js.Value) (*Request, error) {
 	reqValue, err := o.base.jsObjectStore.Call("put", value)
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	return wrapRequest(o.base.txn, reqValue), nil
 }
@@ -180,7 +180,7 @@ func (o *ObjectStore) Put(value js.Value) (*Request, error) {
 func (o *ObjectStore) PutKey(key, value js.Value) (*Request, error) {
 	reqValue, err := o.base.jsObjectStore.Call("put", value, key)
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	return wrapRequest(o.base.txn, reqValue), nil
 }

--- a/idb/open_db_request.go
+++ b/idb/open_db_request.go
@@ -45,7 +45,7 @@ func newOpenDBRequest(ctx context.Context, req *Request, upgrader Upgrader) (*Op
 	}
 	_, err = req.jsRequest.Call(addEventListener, "upgradeneeded", upgrade)
 	if err != nil {
-		return nil, err
+		return nil, tryAsDOMException(err)
 	}
 	go func() {
 		<-ctx.Done()
@@ -75,7 +75,7 @@ func openDBListenSuccess(req *Request) error {
 		return err
 	}
 	_, err = jsDB.Call(addEventListener, "versionchange", versionChange)
-	return err
+	return tryAsDOMException(err)
 }
 
 func openDBUpgradeNeeded(req *Request, upgrader Upgrader, args []safejs.Value) error {

--- a/idb/request.go
+++ b/idb/request.go
@@ -85,12 +85,7 @@ func (r *Request) Err() (err error) {
 	if err != nil {
 		return err
 	}
-	if truthy, err := jsErr.Truthy(); err != nil {
-		return err
-	} else if truthy {
-		return js.Error{Value: safejs.Unsafe(jsErr)}
-	}
-	return nil
+	return domExceptionAsError(jsErr)
 }
 
 func (r *Request) await(ctx context.Context) (result safejs.Value, awaitErr error) {
@@ -183,7 +178,7 @@ func (r *Request) listen(ctx context.Context, success, failed func()) error {
 		}
 		_, err = r.jsRequest.Call(addEventListener, "error", errFunc)
 		if err != nil {
-			panic(err)
+			return tryAsDOMException(err)
 		}
 		go func() {
 			<-ctx.Done()
@@ -206,7 +201,7 @@ func (r *Request) listen(ctx context.Context, success, failed func()) error {
 		}
 		_, err = r.jsRequest.Call(addEventListener, "success", successFunc)
 		if err != nil {
-			panic(err)
+			return tryAsDOMException(err)
 		}
 		go func() {
 			<-ctx.Done()

--- a/idb/transaction.go
+++ b/idb/transaction.go
@@ -17,10 +17,6 @@ var (
 	errNotInTransaction = errors.New("Not part of a transaction")
 )
 
-var (
-	ErrAborted = DOMException{name: "AbortError"}
-)
-
 func checkSupportsTransactionCommit() bool {
 	idbTransaction, err := safejs.Global().Get("IDBTransaction")
 	if err != nil {

--- a/idb/transaction_test.go
+++ b/idb/transaction_test.go
@@ -81,7 +81,7 @@ func TestTransactionAbortErr(t *testing.T) {
 	resultErr := txn.listenFinished(context.Background())
 	assert.NoError(t, txn.Abort())
 	err = <-resultErr
-	assert.ErrorIs(t, ErrAborted, err)
+	assert.ErrorIs(t, err, NewDOMException("AbortError"))
 	err = txn.Err()
 	assert.NoError(t, err)
 }

--- a/idb/transaction_test.go
+++ b/idb/transaction_test.go
@@ -81,9 +81,7 @@ func TestTransactionAbortErr(t *testing.T) {
 	resultErr := txn.listenFinished(context.Background())
 	assert.NoError(t, txn.Abort())
 	err = <-resultErr
-	if assert.Error(t, err) {
-		assert.Equal(t, "transaction aborted", err.Error())
-	}
+	assert.ErrorIs(t, ErrAborted, err)
 	err = txn.Err()
 	assert.NoError(t, err)
 }

--- a/idb/transaction_test.go
+++ b/idb/transaction_test.go
@@ -27,18 +27,42 @@ func TestTransactionDatabase(t *testing.T) {
 
 func TestTransactionDurability(t *testing.T) {
 	t.Parallel()
+	const storeName = "mystore"
 	db := testDB(t, func(db *Database) {
-		_, err := db.CreateObjectStore("mystore", ObjectStoreOptions{})
+		_, err := db.CreateObjectStore(storeName, ObjectStoreOptions{})
 		assert.NoError(t, err)
 	})
-	txn, err := db.TransactionWithOptions(TransactionOptions{
-		Durability: DurabilityStrict,
-	}, "mystore")
-	assert.NoError(t, err)
 
-	durability, err := txn.Durability()
-	assert.NoError(t, err)
-	assert.Equal(t, DurabilityStrict, durability)
+	for _, tc := range []struct {
+		durability   TransactionDurability
+		expectString string
+	}{
+		{
+			durability:   DurabilityDefault,
+			expectString: "default",
+		},
+		{
+			durability:   DurabilityRelaxed,
+			expectString: "relaxed",
+		},
+		{
+			durability:   DurabilityStrict,
+			expectString: "strict",
+		},
+	} {
+		tc := tc // enable parallel sub-tests
+		t.Run(tc.durability.String(), func(t *testing.T) {
+			t.Parallel()
+			txn, err := db.TransactionWithOptions(TransactionOptions{
+				Durability: tc.durability,
+			}, storeName)
+			assert.NoError(t, err)
+			dur, err := txn.Durability()
+			assert.NoError(t, err)
+			assert.Equal(t, tc.durability, dur)
+			assert.Equal(t, tc.expectString, dur.String())
+		})
+	}
 }
 
 func TestTransactionAbortErr(t *testing.T) {


### PR DESCRIPTION

* Attempt to parse all `js.Value.Call()` errors as `DOMException`s
* Expose a `NewDOMException()` constructor and `Is(error) bool` method for easy `errors.Is()` comparisons
* Add more txn durability mode tests
